### PR TITLE
Implement DFS-based maze generation

### DIFF
--- a/DepthFirstPaths.java
+++ b/DepthFirstPaths.java
@@ -66,41 +66,52 @@ public class DepthFirstPaths {
 
     // depth first search from v
     private void dfs(Graph G, int v) {
-        // TODO: Zeilen hinzufuegen
+        // mark node and store preorder
         marked[v] = true;
+        preorder.add(v);
+
+        // explore neighbors
         for (int w : G.adj(v)) {
             if (!marked[w]) {
+                edgeTo[w] = v;
+                distTo[w] = distTo[v] + 1;
                 dfs(G, w);
             }
         }
+
+        // node finished
+        postorder.add(v);
     }
 
     public void nonrecursiveDFS(Graph G) {
-        // TODO: Zeilen hinzufuegen
+        // initialise arrays
         marked = new boolean[G.V()];
-        // to be able to iterate over each adjacency list, keeping track of which
-        // vertex in each adjacency list needs to be explored next
-        Iterator<Integer>[] adj = (Iterator<Integer>[]) new Iterator[G.V()];
-        for (int v = 0; v < G.V(); v++)
-            adj[v] = G.adj(v).iterator();
 
-        // depth-first search using an explicit stack
+        // for preorder/postorder the queues are already set up in constructor
+        Iterator<Integer>[] adj = (Iterator<Integer>[]) new Iterator[G.V()];
+        for (int v = 0; v < G.V(); v++) {
+            adj[v] = G.adj(v).iterator();
+        }
+
         Stack<Integer> stack = new Stack<Integer>();
         marked[s] = true;
+        preorder.add(s);
         stack.push(s);
         while (!stack.isEmpty()) {
             int v = stack.peek();
             if (adj[v].hasNext()) {
                 int w = adj[v].next();
                 if (!marked[w]) {
-                    // discovered vertex w for the first time
                     marked[w] = true;
+                    edgeTo[w] = v;
+                    distTo[w] = distTo[v] + 1;
+                    preorder.add(w);
                     stack.push(w);
                 }
             } else {
+                postorder.add(v);
                 stack.pop();
             }
-
         }
     }
 
@@ -129,7 +140,15 @@ public class DepthFirstPaths {
      * 
      */
     public List<Integer> pathTo(int v) {
-        // TODO
+        validateVertex(v);
+        if (!hasPathTo(v)) return null;
+
+        LinkedList<Integer> path = new LinkedList<Integer>();
+        for (int x = v; x != s; x = edgeTo[x]) {
+            path.addFirst(x);
+        }
+        path.addFirst(s);
+        return path;
     }
 
     /**

--- a/Maze.java
+++ b/Maze.java
@@ -35,7 +35,9 @@ public class Maze{
      * @throws IllegalArgumentException unless both {@code 0 <= v < V} and {@code 0 <= w < V}
      */
     public void addEdge(int v, int w) {
-		// TODO
+        if (!hasEdge(v, w)) {
+            M.addEdge(v, w);
+        }
     }
     
     /**
@@ -45,15 +47,35 @@ public class Maze{
      * @return true or false
      */
     public boolean hasEdge( int v, int w){
-		// TODO
-    }	
+        if (v == w) {
+            return true;
+        }
+        for (int adj : M.adj(v)) {
+            if (adj == w) {
+                return true;
+            }
+        }
+        return false;
+    }
     
     /**
      * Builds a grid as a graph.
      * @return Graph G -- Basic grid on which the Maze is built
      */
     public Graph mazegrid() {
-		// TODO
+        Graph G = new Graph(N * N);
+        for (int row = 0; row < N; row++) {
+            for (int col = 0; col < N; col++) {
+                int v = row * N + col;
+                if (col < N - 1) {
+                    G.addEdge(v, row * N + col + 1);
+                }
+                if (row < N - 1) {
+                    G.addEdge(v, (row + 1) * N + col);
+                }
+            }
+        }
+        return G;
     }
     
     /**
@@ -61,7 +83,16 @@ public class Maze{
      * The maze is build with a randomized DFS as the Graph M.
      */
     private void buildMaze() {
-		// TODO
+        Graph grid = mazegrid();
+        RandomDepthFirstPaths rdfs = new RandomDepthFirstPaths(grid, startnode);
+        rdfs.randomDFS(grid);
+        int[] parent = rdfs.edge();
+        for (int v = 0; v < M.V(); v++) {
+            if (v != startnode) {
+                int p = parent[v];
+                addEdge(v, p);
+            }
+        }
     }
 
     /**
@@ -71,7 +102,9 @@ public class Maze{
      * @return List<Integer> -- a list of nodes on the path from v to w (both included) in the right order.
      */
     public List<Integer> findWay(int v, int w){
-		// TODO
+        DepthFirstPaths dfs = new DepthFirstPaths(M, v);
+        dfs.nonrecursiveDFS(M);
+        return dfs.pathTo(w);
     }
     
     /**

--- a/RandomDepthFirstPaths.java
+++ b/RandomDepthFirstPaths.java
@@ -2,6 +2,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Stack;
+import java.util.LinkedList;
 
 public class RandomDepthFirstPaths {
     private boolean[] marked; // marked[v] = is there an s-v path?
@@ -28,11 +29,41 @@ public class RandomDepthFirstPaths {
 
     // depth first search from v
     private void randomDFS(Graph G, int v) {
-        // TODO
+        marked[v] = true;
+        Collections.shuffle(G.adj(v));
+        for (int w : G.adj(v)) {
+            if (!marked[w]) {
+                edgeTo[w] = v;
+                randomDFS(G, w);
+            }
+        }
     }
 
     public void randomNonrecursiveDFS(Graph G) {
-        // TODO
+        marked = new boolean[G.V()];
+
+        Iterator<Integer>[] adj = (Iterator<Integer>[]) new Iterator[G.V()];
+        for (int v = 0; v < G.V(); v++) {
+            Collections.shuffle(G.adj(v));
+            adj[v] = G.adj(v).iterator();
+        }
+
+        Stack<Integer> stack = new Stack<Integer>();
+        marked[s] = true;
+        stack.push(s);
+        while (!stack.isEmpty()) {
+            int v = stack.peek();
+            if (adj[v].hasNext()) {
+                int w = adj[v].next();
+                if (!marked[w]) {
+                    marked[w] = true;
+                    edgeTo[w] = v;
+                    stack.push(w);
+                }
+            } else {
+                stack.pop();
+            }
+        }
     }
 
     /**
@@ -59,7 +90,15 @@ public class RandomDepthFirstPaths {
      * 
      */
     public List<Integer> pathTo(int v) {
-        // TODO
+        validateVertex(v);
+        if (!hasPathTo(v)) return null;
+
+        LinkedList<Integer> path = new LinkedList<Integer>();
+        for (int x = v; x != s; x = edgeTo[x]) {
+            path.addFirst(x);
+        }
+        path.addFirst(s);
+        return path;
     }
 
     public int[] edge() {


### PR DESCRIPTION
## Summary
- add full DFS traversal with preorder/postorder and path reconstruction
- implement randomized DFS for maze creation
- build maze grid and search paths through the maze

## Testing
- `javac Config.java DepthFirstPaths.java Graph.java GridGraph.java Maze.java RandomDepthFirstPaths.java StdDraw.java Visualization.java`

------
https://chatgpt.com/codex/tasks/task_e_6852b17be93483219169be571d954f81