### PR TITLE
Implement DFS-based maze generation

### DIFF
--- a/DepthFirstPaths.java
+++ b/DepthFirstPaths.java
@@ -66,41 +66,52 @@ public class DepthFirstPaths {
 
     // depth first search from v
     private void dfs(Graph G, int v) {
-        // TODO: Zeilen hinzufuegen
+        // mark node and store preorder
         marked[v] = true;
+        preorder.add(v);
+
+        // explore neighbors
         for (int w : G.adj(v)) {
             if (!marked[w]) {
+                edgeTo[w] = v;
+                distTo[w] = distTo[v] + 1;
                 dfs(G, w);
             }
         }
+
+        // node finished
+        postorder.add(v);
     }
 
     public void nonrecursiveDFS(Graph G) {
-        // TODO: Zeilen hinzufuegen
+        // initialise arrays
         marked = new boolean[G.V()];
-        // to be able to iterate over each adjacency list, keeping track of which
-        // vertex in each adjacency list needs to be explored next
-        Iterator<Integer>[] adj = (Iterator<Integer>[]) new Iterator[G.V()];
-        for (int v = 0; v < G.V(); v++)
-            adj[v] = G.adj(v).iterator();
 
-        // depth-first search using an explicit stack
+        // for preorder/postorder the queues are already set up in constructor
+        Iterator<Integer>[] adj = (Iterator<Integer>[]) new Iterator[G.V()];
+        for (int v = 0; v < G.V(); v++) {
+            adj[v] = G.adj(v).iterator();
+        }
+
         Stack<Integer> stack = new Stack<Integer>();
         marked[s] = true;
+        preorder.add(s);
         stack.push(s);
         while (!stack.isEmpty()) {
             int v = stack.peek();
             if (adj[v].hasNext()) {
                 int w = adj[v].next();
                 if (!marked[w]) {
-                    // discovered vertex w for the first time
                     marked[w] = true;
+                    edgeTo[w] = v;
+                    distTo[w] = distTo[v] + 1;
+                    preorder.add(w);
                     stack.push(w);
                 }
             } else {
+                postorder.add(v);
                 stack.pop();
             }
-
         }
     }
 
@@ -129,7 +140,15 @@ public class DepthFirstPaths {
      * 
      */
     public List<Integer> pathTo(int v) {
-        // TODO
+        validateVertex(v);
+        if (!hasPathTo(v)) return null;
+
+        LinkedList<Integer> path = new LinkedList<Integer>();
+        for (int x = v; x != s; x = edgeTo[x]) {
+            path.addFirst(x);
+        }
+        path.addFirst(s);
+        return path;
     }
 
     /**

--- a/DepthFirstPathsTest.java
+++ b/DepthFirstPathsTest.java
@@ -1,22 +1,83 @@
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
+import java.util.List;
 
 class DepthFirstPathsTest {
 
-	@Test
-	void testDfs() {
-		fail("Not yet implemented");
-	}
+        @Test
+        void testDfs() {
+                Graph g = new Graph(5);
+                g.addEdge(0, 1);
+                g.addEdge(0, 2);
+                g.addEdge(1, 3);
+                g.addEdge(2, 3);
 
-	@Test
-	void testNonrecursiveDFS() {
-		fail("Not yet implemented");
-	}
+                DepthFirstPaths dfs = new DepthFirstPaths(g, 0);
+                dfs.dfs(g);
 
-	@Test
-	void testPathTo() {
-		fail("Not yet implemented");
-	}
+                assertEquals(4, dfs.pre().size());
+                assertEquals(4, dfs.post().size());
+
+                int[] expectedPre = {0, 1, 3, 2};
+                int[] expectedPost = {2, 3, 1, 0};
+
+                int idx = 0;
+                for (int v : dfs.pre()) {
+                        assertEquals(expectedPre[idx++], v);
+                }
+                idx = 0;
+                for (int v : dfs.post()) {
+                        assertEquals(expectedPost[idx++], v);
+                }
+
+                int[] dist = dfs.dist();
+                assertEquals(0, dist[0]);
+                assertEquals(1, dist[1]);
+                assertEquals(2, dist[3]);
+                assertEquals(3, dist[2]);
+
+        }
+
+        @Test
+        void testNonrecursiveDFS() {
+                Graph g = new Graph(5);
+                g.addEdge(0, 1);
+                g.addEdge(0, 2);
+                g.addEdge(1, 3);
+                g.addEdge(2, 3);
+
+                DepthFirstPaths dfs = new DepthFirstPaths(g, 0);
+                dfs.nonrecursiveDFS(g);
+
+                int[] expectedPre = {0, 1, 3, 2};
+                int[] expectedPost = {2, 3, 1, 0};
+
+                int idx = 0;
+                for (int v : dfs.pre()) {
+                        assertEquals(expectedPre[idx++], v);
+                }
+                idx = 0;
+                for (int v : dfs.post()) {
+                        assertEquals(expectedPost[idx++], v);
+                }
+        }
+
+        @Test
+        void testPathTo() {
+                Graph g = new Graph(5);
+                g.addEdge(0, 1);
+                g.addEdge(0, 2);
+                g.addEdge(1, 3);
+                g.addEdge(2, 3);
+
+                DepthFirstPaths dfs = new DepthFirstPaths(g, 0);
+                dfs.nonrecursiveDFS(g);
+
+                List<Integer> path = dfs.pathTo(2);
+                assertEquals(List.of(0, 1, 3, 2), path);
+
+                assertNull(dfs.pathTo(4));
+        }
 
 }
 

--- a/Maze.java
+++ b/Maze.java
@@ -35,7 +35,9 @@ public class Maze{
      * @throws IllegalArgumentException unless both {@code 0 <= v < V} and {@code 0 <= w < V}
      */
     public void addEdge(int v, int w) {
-		// TODO
+        if (!hasEdge(v, w)) {
+            M.addEdge(v, w);
+        }
     }
     
     /**
@@ -45,15 +47,35 @@ public class Maze{
      * @return true or false
      */
     public boolean hasEdge( int v, int w){
-		// TODO
-    }	
+        if (v == w) {
+            return true;
+        }
+        for (int adj : M.adj(v)) {
+            if (adj == w) {
+                return true;
+            }
+        }
+        return false;
+    }
     
     /**
      * Builds a grid as a graph.
      * @return Graph G -- Basic grid on which the Maze is built
      */
     public Graph mazegrid() {
-		// TODO
+        Graph G = new Graph(N * N);
+        for (int row = 0; row < N; row++) {
+            for (int col = 0; col < N; col++) {
+                int v = row * N + col;
+                if (col < N - 1) {
+                    G.addEdge(v, row * N + col + 1);
+                }
+                if (row < N - 1) {
+                    G.addEdge(v, (row + 1) * N + col);
+                }
+            }
+        }
+        return G;
     }
     
     /**
@@ -61,7 +83,16 @@ public class Maze{
      * The maze is build with a randomized DFS as the Graph M.
      */
     private void buildMaze() {
-		// TODO
+        Graph grid = mazegrid();
+        RandomDepthFirstPaths rdfs = new RandomDepthFirstPaths(grid, startnode);
+        rdfs.randomDFS(grid);
+        int[] parent = rdfs.edge();
+        for (int v = 0; v < M.V(); v++) {
+            if (v != startnode) {
+                int p = parent[v];
+                addEdge(v, p);
+            }
+        }
     }
 
     /**
@@ -71,7 +102,9 @@ public class Maze{
      * @return List<Integer> -- a list of nodes on the path from v to w (both included) in the right order.
      */
     public List<Integer> findWay(int v, int w){
-		// TODO
+        DepthFirstPaths dfs = new DepthFirstPaths(M, v);
+        dfs.nonrecursiveDFS(M);
+        return dfs.pathTo(w);
     }
     
     /**

--- a/MazeTest.java
+++ b/MazeTest.java
@@ -1,32 +1,61 @@
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
+import java.util.List;
 
 class MazeTest {
 
-	@Test
-	void testMazeIntInt() {
-		fail("Not yet implemented");
-	}
+        @Test
+        void testMazeIntInt() {
+                Maze m = new Maze(2, 0);
+                Graph g = m.M();
+                assertEquals(4, g.V());
+                assertEquals(3, g.E());
+                assertEquals(0, m.startnode);
+        }
 
 	@Test
-	void testAddEdge() {
-		fail("Not yet implemented");
-	}
+        void testAddEdge() {
+                Maze m = new Maze(1, 0);
+                Graph g = m.M();
+                assertEquals(0, g.E());
+                m.addEdge(0, 0);
+                assertEquals(0, g.E());
+        }
 
 	@Test
-	void testHasEdge() {
-		fail("Not yet implemented");
-	}
+        void testHasEdge() {
+                Maze m = new Maze(2, 0);
+                Graph g = m.M();
+                for (int v = 0; v < g.V(); v++) {
+                        for (int w : g.adj(v)) {
+                                assertTrue(m.hasEdge(v, w));
+                        }
+                }
+        }
 
 	@Test
-	void testMazegrid() {
-		fail("Not yet implemented");
-	}
+        void testMazegrid() {
+                Maze m = new Maze(3, 0);
+                Graph g = m.mazegrid();
+                assertEquals(9, g.V());
+                assertEquals(2 * 3 * (3 - 1), g.E());
+                assertTrue(g.adj(0).contains(1));
+                assertTrue(g.adj(0).contains(3));
+        }
 
 	@Test
-	void testFindWay() {
-		fail("Not yet implemented");
-	}
+        void testFindWay() {
+                Maze m = new Maze(3, 0);
+                List<Integer> path = m.findWay(0, 8);
+                assertNotNull(path);
+                assertEquals(0, (int) path.get(0));
+                assertEquals(8, (int) path.get(path.size() - 1));
+                // verify consecutive edges exist
+                Graph g = m.M();
+                for (int i = 0; i < path.size() - 1; i++) {
+                        assertTrue(g.adj(path.get(i)).contains(path.get(i + 1)));
+                }
+        }
 
 }
 

--- a/RandomDepthFirstPaths.java
+++ b/RandomDepthFirstPaths.java
@@ -2,6 +2,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Stack;
+import java.util.LinkedList;
 
 public class RandomDepthFirstPaths {
     private boolean[] marked; // marked[v] = is there an s-v path?
@@ -28,11 +29,41 @@ public class RandomDepthFirstPaths {
 
     // depth first search from v
     private void randomDFS(Graph G, int v) {
-        // TODO
+        marked[v] = true;
+        Collections.shuffle(G.adj(v));
+        for (int w : G.adj(v)) {
+            if (!marked[w]) {
+                edgeTo[w] = v;
+                randomDFS(G, w);
+            }
+        }
     }
 
     public void randomNonrecursiveDFS(Graph G) {
-        // TODO
+        marked = new boolean[G.V()];
+
+        Iterator<Integer>[] adj = (Iterator<Integer>[]) new Iterator[G.V()];
+        for (int v = 0; v < G.V(); v++) {
+            Collections.shuffle(G.adj(v));
+            adj[v] = G.adj(v).iterator();
+        }
+
+        Stack<Integer> stack = new Stack<Integer>();
+        marked[s] = true;
+        stack.push(s);
+        while (!stack.isEmpty()) {
+            int v = stack.peek();
+            if (adj[v].hasNext()) {
+                int w = adj[v].next();
+                if (!marked[w]) {
+                    marked[w] = true;
+                    edgeTo[w] = v;
+                    stack.push(w);
+                }
+            } else {
+                stack.pop();
+            }
+        }
     }
 
     /**
@@ -59,7 +90,15 @@ public class RandomDepthFirstPaths {
      * 
      */
     public List<Integer> pathTo(int v) {
-        // TODO
+        validateVertex(v);
+        if (!hasPathTo(v)) return null;
+
+        LinkedList<Integer> path = new LinkedList<Integer>();
+        for (int x = v; x != s; x = edgeTo[x]) {
+            path.addFirst(x);
+        }
+        path.addFirst(s);
+        return path;
     }
 
     public int[] edge() {

--- a/RandomDepthFirstPathsTest.java
+++ b/RandomDepthFirstPathsTest.java
@@ -1,22 +1,78 @@
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
+import java.util.List;
 
 class RandomDepthFirstPathsTest {
 
-	@Test
-	void testRandomDFS() {
-		fail("Not yet implemented");
-	}
+        @Test
+        void testRandomDFS() {
+                Graph g = new Graph(4);
+                g.addEdge(0, 1);
+                g.addEdge(0, 2);
+                g.addEdge(1, 3);
+                g.addEdge(2, 3);
 
-	@Test
-	void testRandomNonrecursiveDFS() {
-		fail("Not yet implemented");
-	}
+                RandomDepthFirstPaths rdfs = new RandomDepthFirstPaths(g, 0);
+                rdfs.randomDFS(g);
 
-	@Test
-	void testPathTo() {
-		fail("Not yet implemented");
-	}
+                for (int v = 0; v < g.V(); v++) {
+                        assertTrue(rdfs.hasPathTo(v));
+                }
+
+                List<Integer> path = rdfs.pathTo(3);
+                assertEquals(0, path.get(0));
+                assertEquals(3, path.get(path.size() - 1));
+                assertTrue(validPath(path, g));
+        }
+
+        @Test
+        void testRandomNonrecursiveDFS() {
+                Graph g = new Graph(4);
+                g.addEdge(0, 1);
+                g.addEdge(0, 2);
+                g.addEdge(1, 3);
+                g.addEdge(2, 3);
+
+                RandomDepthFirstPaths rdfs = new RandomDepthFirstPaths(g, 0);
+                rdfs.randomNonrecursiveDFS(g);
+
+                for (int v = 0; v < g.V(); v++) {
+                        assertTrue(rdfs.hasPathTo(v));
+                }
+
+                List<Integer> path = rdfs.pathTo(3);
+                assertEquals(0, path.get(0));
+                assertEquals(3, path.get(path.size() - 1));
+                assertTrue(validPath(path, g));
+        }
+
+        @Test
+        void testPathTo() {
+                Graph g = new Graph(4);
+                g.addEdge(0, 1);
+                g.addEdge(0, 2);
+                g.addEdge(1, 3);
+                g.addEdge(2, 3);
+
+                RandomDepthFirstPaths rdfs = new RandomDepthFirstPaths(g, 0);
+                rdfs.randomDFS(g);
+
+                List<Integer> path = rdfs.pathTo(3);
+                assertEquals(0, path.get(0));
+                assertEquals(3, path.get(path.size() - 1));
+                assertTrue(validPath(path, g));
+        }
+
+        private boolean validPath(List<Integer> path, Graph g) {
+                for (int i = 0; i < path.size() - 1; i++) {
+                        int v = path.get(i);
+                        int w = path.get(i + 1);
+                        if (!g.adj(v).contains(w)) {
+                                return false;
+                        }
+                }
+                return true;
+        }
 
 }
 


### PR DESCRIPTION
## Summary
- add full DFS traversal with preorder/postorder and path reconstruction
- implement randomized DFS for maze creation
- build maze grid and search paths through the maze
- add unit tests for DFS and maze logic

## Testing
- `javac -cp .:/usr/share/java/junit-platform-console-standalone-1.9.1.jar *.java`
- `java -jar /usr/share/java/junit-platform-console-standalone-1.9.1.jar -cp . --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_6852b17be93483219169be571d954f81