### PR TITLE
Initialize marked array before DFS

### DIFF
--- a/DepthFirstPaths.java
+++ b/DepthFirstPaths.java
@@ -61,6 +61,7 @@ public class DepthFirstPaths {
     }
 
     public void dfs(Graph G) {
+        marked = new boolean[G.V()];
         dfs(G, s);
     }
 


### PR DESCRIPTION
## Summary
- reset `marked` array each time `dfs` is executed to ensure a clean search state

## Testing
- `javac Config.java Graph.java GridGraph.java In.java Maze.java DepthFirstPaths.java RandomDepthFirstPaths.java Visualization.java StdDraw.java`

------
https://chatgpt.com/codex/tasks/task_e_6852d30b485483219139e7ac5aa6e0b4